### PR TITLE
Documentation for the new `retain-permissions` query parameter.

### DIFF
--- a/api/endpoints/collaborator-lists.md
+++ b/api/endpoints/collaborator-lists.md
@@ -201,3 +201,19 @@ $ curl -sH "$AUTH_HEADER" -d '{"members":["ipctest"]}' http://exmaple.org/collab
   ]
 }
 ```
+
+To retain permissions that had been granted to the collaborator list for removed members, the `retain-permissions` query
+parameter can be added and set to `true`:
+
+```
+$ curl -sH "$AUTH_HEADER" -d '{"members":["ipctest"]}' "http://example.org/collaborator-lists/foo/members/deleter?retain-permissions=true" | jq .
+{
+  "results": [
+    {
+      "success": true,
+      "subject_id": "ipctest",
+      "subject_name": "IPC Test"
+    }
+  ]
+}
+```

--- a/api/endpoints/collaborator-lists.md
+++ b/api/endpoints/collaborator-lists.md
@@ -147,6 +147,23 @@ $ curl -sX DELETE -H "$AUTH_HEADER" "http://example.org/collaborator-lists/bar" 
 }
 ```
 
+To allow members to retain permissions that had been granted to the collaborator list, the `retain-permissions` query
+parameter can be added and set to `true`:
+
+```
+$ curl -sX DELETE -H "$AUTH_HEADER" "http://example.org/collaborator-lists/bar?retain-permissions=true" | jq .
+{
+  "description": "bar",
+  "display_extension": "bar",
+  "display_name": "iplant:de:de-2:users:dennis:collaborator-lists:bar",
+  "extension": "bar",
+  "name": "bar",
+  "type": "group",
+  "id": "f449ea254cdf480a80a7ad96d785389d",
+  "id_index": "10293"
+}
+```
+
 ## Listing Collaborator List Members
 
 Secured Endpoint: GET /collaborator-lists/{name}/members


### PR DESCRIPTION
This parameter has been added to two of the existing collaborator list endpoints.
